### PR TITLE
Fix: Type error for latest Expo & React Native

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ type VariantSchema<V extends VariantShape> = {
   [Variant in keyof V]?: StringToBoolean<keyof V[Variant]> | undefined;
 };
 
-export type Config<V extends VariantShape = VariantShape> = {
-  base?: Style;
+export type Config<K extends Style, V extends VariantShape = VariantShape> = {
+  base?: K;
   variants?: V;
   defaultVariants?: VariantSchema<V>;
   compoundVariants?: Array<CompoundVariant<V>>;
@@ -33,14 +33,14 @@ type Props<V> = V extends VariantShape
   : never;
 
 export const sv =
-  <V extends VariantShape = VariantShape>({
+  <K extends Style, V extends VariantShape = VariantShape>({
     base,
     defaultVariants,
     variants,
     compoundVariants = [],
-  }: Config<V>) =>
+  }: Config<K, V>) =>
   (_options?: Props<V>) => {
-    const styles: Style = {};
+    const styles: K = Object.assign({});
 
     const options = _options || ({} as Props<V>);
 


### PR DESCRIPTION
I updated my project to latest version of `"expo": "~52.0.11",` and `"react-native": "0.76.3",` and I got this error about return type not in line with what was expected.

```
No overload matches this call.
  Overload 1 of 2, '(props: TextProps): Text', gave the following error.
    Type 'Style' is not assignable to type 'StyleProp<TextStyle>'.
      Type 'ViewStyle' is not assignable to type 'StyleProp<TextStyle>'.
        Type 'ViewStyle' is not assignable to type 'TextStyle'.
          Types of property 'userSelect' are incompatible.
            Type 'string | undefined' is not assignable to type '"none" | "auto" | "contain" | "text" | "all" | undefined'.
              Type 'string' is not assignable to type '"none" | "auto" | "contain" | "text" | "all" | undefined'.
  Overload 2 of 2, '(props: TextProps, context: any): Text', gave the following error.
    Type 'Style' is not assignable to type 'StyleProp<TextStyle>'.
      Type 'ViewStyle' is not assignable to type 'StyleProp<TextStyle>'.
        Type 'ViewStyle' is not assignable to type 'TextStyle'.
          Types of property 'userSelect' are incompatible.
            Type 'string | undefined' is not assignable to type '"none" | "auto" | "contain" | "text" | "all" | undefined'.
              Type 'string' is not assignable to type '"none" | "auto" | "contain" | "text" | "all" | undefined'.ts(2769)
```

I fixed it by making the return type be same as base.

Typecheck, lint and test are all passing.